### PR TITLE
Add choice of kernel in Jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ git clone https://github.com/madanvikram/deep_learning_workshop
 
 7. Click on "deep_learning_workshop"
 
-
+8. If asked to choose a kernel, select "conda_mxnet_p36"


### PR DESCRIPTION
When I followed the preceding instructions, Jupyter asked for the kernel. Selecting conda_mxnet_p36 worked with the tutorial with only a benign warning about SSL deprecation during one of the imports.